### PR TITLE
Improved performance and memory usage

### DIFF
--- a/Mipa.Benchmark/Mipa.Benchmark.csproj
+++ b/Mipa.Benchmark/Mipa.Benchmark.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Mipa\Mipa.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Mipa.Benchmark/ParseBenchmark.cs
+++ b/Mipa.Benchmark/ParseBenchmark.cs
@@ -1,0 +1,39 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace Mipa.Benchmark;
+
+[MemoryDiagnoser]
+public class ParseBenchmark
+{
+    private static readonly IMipaParser Parser = new MipaParser();
+
+    [Benchmark]
+    public void ParseEmpty()
+    {
+        Parser.Parse("");
+    }
+
+    [Benchmark]
+    public void ParseHelloWorld()
+    {
+        Parser.Parse("hello world");
+    }
+
+    [Benchmark]
+    public void ParseSingleArgument()
+    {
+        Parser.Parse("hello world key:value");
+    }
+
+    [Benchmark]
+    public void ParseMultipleArguments()
+    {
+        Parser.Parse("key2:value2 hello world key:value");
+    }
+
+    [Benchmark]
+    public void ParseMultipleArgumentsWithQuotes()
+    {
+        Parser.Parse("key2:\"this is value2\" hello world key:\"value\"");
+    }
+}

--- a/Mipa.Benchmark/Program.cs
+++ b/Mipa.Benchmark/Program.cs
@@ -1,0 +1,6 @@
+﻿// See https://aka.ms/new-console-template for more information
+
+using BenchmarkDotNet.Running;
+using Mipa.Benchmark;
+
+BenchmarkRunner.Run<ParseBenchmark>();

--- a/Mipa.Tests/Mipa.Tests.csproj
+++ b/Mipa.Tests/Mipa.Tests.csproj
@@ -13,7 +13,6 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0"/>
         <PackageReference Include="NUnit" Version="3.13.3"/>
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1"/>
-        <PackageReference Include="NUnit.Analyzers" Version="3.6.1"/>
         <PackageReference Include="coverlet.collector" Version="6.0.0"/>
     </ItemGroup>
 

--- a/Mipa.sln
+++ b/Mipa.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mipa", "Mipa\Mipa.csproj", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mipa.Tests", "Mipa.Tests\Mipa.Tests.csproj", "{D657859A-EB12-42E0-A3C6-EB0680127600}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mipa.Benchmark", "Mipa.Benchmark\Mipa.Benchmark.csproj", "{7D3987AD-73A7-4E0E-9DF7-5D6C60313797}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{D657859A-EB12-42E0-A3C6-EB0680127600}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D657859A-EB12-42E0-A3C6-EB0680127600}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D657859A-EB12-42E0-A3C6-EB0680127600}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D3987AD-73A7-4E0E-9DF7-5D6C60313797}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D3987AD-73A7-4E0E-9DF7-5D6C60313797}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D3987AD-73A7-4E0E-9DF7-5D6C60313797}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D3987AD-73A7-4E0E-9DF7-5D6C60313797}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/Mipa/KeyValueRegex.cs
+++ b/Mipa/KeyValueRegex.cs
@@ -1,9 +1,0 @@
-using System.Text.RegularExpressions;
-
-namespace Mipa;
-
-internal partial class KeyValueRegex
-{
-    [GeneratedRegex("(\\w+):((?:\\\"[^\"]*\\\"|\\S+))", RegexOptions.IgnoreCase, "en-US")]
-    internal static partial Regex Get();
-}

--- a/Mipa/Mipa.csproj
+++ b/Mipa/Mipa.csproj
@@ -10,6 +10,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <RepositoryUrl>https://github.com/velddev/mipa</RepositoryUrl>
         <RepositoryType>GIT</RepositoryType>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 
 </Project>

--- a/Mipa/ParseResult.cs
+++ b/Mipa/ParseResult.cs
@@ -1,26 +1,39 @@
+using System.Collections.Immutable;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
 namespace Mipa;
 
-public record ParseResult
+public readonly struct ParseResult
 {
     /// <summary>
     /// Remainder of the content that is unparsed.
     /// </summary>
     public string Content { get; init; }
-    public IReadOnlyList<KeyValuePair<string, string>> Arguments { get; init; }
+    public ReadOnlyMemory<KeyValuePair<ReadOnlyMemory<char>, ReadOnlyMemory<char>>> Arguments { get; init; }
     
-    public string? GetArgument(string key)
+    public ReadOnlyMemory<char> GetArgument(string key)
     {
-        return Arguments.FirstOrDefault(x => x.Key == key).Value;
+        foreach (var argument in Arguments.Span)
+        {
+            if (argument.Key.Span.SequenceEqual(key))
+            {
+                return argument.Value;
+            }
+        }
+
+        return default;
     }
-    public T? GetArgument<T>(string key) where T : IParsable<T>
+
+    public T? GetArgument<T>(string key) where T : ISpanParsable<T>
     {
         var argument = GetArgument(key);
-        if (argument == null)
+        if (argument.IsEmpty)
         {
             return default;
         }
 
-        if (!T.TryParse(argument, null, out var result))
+        if (!T.TryParse(argument.Span, null, out var result))
         {
             return default;
         }

--- a/Mipa/Parser.cs
+++ b/Mipa/Parser.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Mipa;
 
@@ -6,32 +7,169 @@ public class MipaParser : IMipaParser
 {
     public ParseResult Parse(string content)
     {
-        if(string.IsNullOrWhiteSpace(content))
+        // Match all key value pairs
+        var memory = content.AsMemory();
+        var maxArguments = memory.Span.Count(':');
+
+        if (maxArguments == 0)
         {
             return new ParseResult
             {
-                Arguments = [],
+                Arguments = Array.Empty<KeyValuePair<ReadOnlyMemory<char>, ReadOnlyMemory<char>>>(),
                 Content = content,
             };
         }
 
-        // match all key value pairs
-        var matches = KeyValueRegex.Get().Matches(content);
-        var arguments = new List<KeyValuePair<string, string>>();
-        var builder = new StringBuilder(content);
-        for (var i = matches.Count - 1; i >= 0; i--)
+        var arguments = new KeyValuePair<ReadOnlyMemory<char>, ReadOnlyMemory<char>>[maxArguments];
+
+        Span<ArgumentPosition> positions = stackalloc ArgumentPosition[maxArguments];
+        var positionIndex = 0;
+        var contentLength = content.Length;
+
+        while (!memory.IsEmpty)
         {
-            var match = matches[i];
-            var key = match.Groups[1].Value;
-            var value = match.Groups[2].Value.Trim('"');
-            arguments.Add(new KeyValuePair<string, string>(key, value));
-            builder.Remove(match.Index, match.Length);
+            // Find the next key value pair
+            var index = memory.Span.IndexOf(':');
+
+            if (index == -1)
+            {
+                break;
+            }
+
+            if (index == 0 || !char.IsAsciiLetterOrDigit(memory.Span[index - 1]))
+            {
+                memory = memory.Slice(index + 1);
+                continue;
+            }
+
+            // Get the value
+            var valueSpan = memory.Slice(index + 1);
+
+            if (valueSpan.Length == 0)
+            {
+                break;
+            }
+
+            var value = GetValue(valueSpan, out var length);
+
+            // Get the key
+            var key = GetKey(memory, index - 1);
+
+            // Add the argument
+            arguments[positionIndex] = new KeyValuePair<ReadOnlyMemory<char>, ReadOnlyMemory<char>>(key, value);
+
+            // Trim whitespace before the key
+            var start = index - key.Length;
+
+            if (start > 0 && char.IsWhiteSpace(memory.Span[start - 1]))
+            {
+                start--;
+            }
+
+            // Trim whitespace after the value
+            var end = index + 1 + length;
+
+            if (end < memory.Length && char.IsWhiteSpace(memory.Span[end]))
+            {
+                end++;
+            }
+
+            // Store the position of the argument in the content
+            var argumentLength = end - start;
+            positions[positionIndex] = new ArgumentPosition(start, argumentLength);
+            contentLength -= argumentLength;
+
+            memory = memory.Slice(end);
+            positionIndex++;
         }
-        
+
         return new ParseResult
         {
-            Content = builder.ToString().Trim(),
-            Arguments = arguments,
+            Content = CreateContent(content, contentLength, positions.Slice(0, positionIndex)),
+            Arguments = arguments.AsMemory(0, positionIndex),
         };
+    }
+
+    private static unsafe string CreateContent(string content, int length, ReadOnlySpan<ArgumentPosition> positions)
+    {
+        if (positions.Length == 0)
+        {
+            return content;
+        }
+
+        var state = new State
+        {
+            Content = content,
+            Positions = (ArgumentPosition*)Unsafe.AsPointer(ref MemoryMarshal.GetReference(positions)),
+            PositionLength = positions.Length,
+        };
+
+        return string.Create(length, state, static (span, state) =>
+        {
+            var chars = state.Content.AsSpan();
+            var positions = new ReadOnlySpan<ArgumentPosition>(state.Positions, state.PositionLength);
+
+            foreach (ref readonly var position in positions)
+            {
+                if (position.Start > 0)
+                {
+                    chars.Slice(0, position.Start).CopyTo(span);
+                    span = span.Slice(position.Start);
+                }
+
+                chars = chars.Slice(position.Start + position.Length);
+            }
+
+            if (!chars.IsEmpty)
+            {
+                chars.CopyTo(span);
+            }
+        });
+    }
+
+    private unsafe struct State
+    {
+        public required string Content;
+        public required ArgumentPosition* Positions;
+        public required int PositionLength;
+    }
+
+    private record struct ArgumentPosition(int Start, int Length);
+
+    private static ReadOnlyMemory<char> GetKey(in ReadOnlyMemory<char> memory, int start)
+    {
+        var index = start - 1;
+
+        while (index >= 0 && char.IsAsciiLetterOrDigit(memory.Span[index]))
+        {
+            index--;
+        }
+
+        return memory.Slice(index + 1, start - index);
+    }
+
+    private static ReadOnlyMemory<char> GetValue(in ReadOnlyMemory<char> memory, out int length)
+    {
+        var quote = memory.Span[0] == '"';
+
+        int index;
+
+        if (quote)
+        {
+            var search = memory.Slice(1);
+            index = search.Span.IndexOf('"');
+            length = index + 2;
+            return search.Slice(0, index);
+        }
+
+        index = memory.Span.IndexOf(' ');
+
+        if (index == -1)
+        {
+            index = memory.Length;
+        }
+
+        length = index;
+        return memory.Slice(0, index);
     }
 }


### PR DESCRIPTION
**Before**
| Method                            | Mean       | Error     | StdDev    | Gen0   | Allocated |
|---------------------------------- |-----------:|----------:|----------:|-------:|----------:|
| ParseEmpty                        |   5.373 ns | 0.0493 ns | 0.0461 ns | 0.0019 |      32 B |
| ParseHelloWorld                   | 160.102 ns | 1.7004 ns | 1.5074 ns | 0.0181 |     304 B |
| ParseSingleArgument               | 389.493 ns | 5.1651 ns | 4.8315 ns | 0.0644 |    1080 B |
| ParseSingleArgumentBetweenContent | 349.253 ns | 5.6797 ns | 5.3128 ns | 0.0615 |    1032 B |
| ParseMultipleArguments            | 522.896 ns | 6.9449 ns | 5.4221 ns | 0.1001 |    1680 B |
| ParseMultipleArgumentsWithQuotes  | 525.849 ns | 4.1642 ns | 3.8952 ns | 0.1078 |    1816 B |

**After**
| Method                           | Mean      | Error     | StdDev    | Gen0   | Allocated |
|--------------------------------- |----------:|----------:|----------:|-------:|----------:|
| ParseEmpty                       |  9.522 ns | 0.0763 ns | 0.0714 ns |      - |         - |
| ParseHelloWorld                  | 10.560 ns | 0.0563 ns | 0.0470 ns |      - |         - |
| ParseSingleArgument              | 46.161 ns | 0.5124 ns | 0.4001 ns | 0.0062 |     104 B |
| ParseMultipleArguments           | 72.213 ns | 0.8378 ns | 0.7837 ns | 0.0081 |     136 B |
| ParseMultipleArgumentsWithQuotes | 80.293 ns | 1.6282 ns | 1.6720 ns | 0.0081 |     136 B |

A lot of breaking changes have been made.
Also `"hello key:value world"` currently parses to the content `"helloworld"`, which is a bug. In the main branche it parses to `"hello  world"`.